### PR TITLE
Clean up srand.php.

### DIFF
--- a/README
+++ b/README
@@ -37,3 +37,15 @@ This software was written based on research funded by the ERC project CODAMODA
 and is released under the New BSD License.
 
 
+USAGE EXAMPLE
+-------------
+
+$c1 =  microtime(true);
+if (isset($_GET['l']))
+   $t = secure_random_bytes($_GET['l']);
+else
+   $t = secure_random_bytes();
+$c2 = microtime(true);
+    
+echo "Token: $t<br>Execution time: " . (int)(($c2-$c1)*1000000);
+

--- a/srand.php
+++ b/srand.php
@@ -143,15 +143,3 @@ function secure_random_bytes($len = 10)
    
    return substr($str, 0, $len);
 }
-
-
-$c1 =  microtime(true);
-if (isset($_GET['l']))
-   $t = secure_random_bytes($_GET['l']);
-else
-   $t = secure_random_bytes();
-$c2 = microtime(true);
-    
-echo "Token: $t<br>Execution time: " . (int)(($c2-$c1)*1000000);
-?>
-


### PR DESCRIPTION
As proposed in #1, I removed the example code from srand.php. I also removed the closing PHP tag, as that can cause problems - especially since there was whitespace after the closing tag.

This makes it much easier to directly integrate this library into other repositories without having to change things.
